### PR TITLE
Fix non-1080p clips on iOS/macOS Telegram

### DIFF
--- a/bot/adapters/rest/rest_responder.py
+++ b/bot/adapters/rest/rest_responder.py
@@ -42,7 +42,13 @@ class RestResponder(AbstractResponder):
             ),
         )
 
-    async def send_video(self, file_path: Path, delete_after_send: bool = True) -> None:
+    async def send_video(
+        self,
+        file_path: Path,
+        delete_after_send: bool = True,
+        width: Optional[int] = None,
+        height: Optional[int] = None,
+    ) -> None:
         background = BackgroundTask(file_path.unlink) if delete_after_send else None
         self.__set_response(
             FileResponse(

--- a/bot/adapters/telegram/telegram_responder.py
+++ b/bot/adapters/telegram/telegram_responder.py
@@ -1,5 +1,6 @@
 import json
 from pathlib import Path
+from typing import Optional
 
 from aiogram.types import (
     BufferedInputFile,
@@ -8,6 +9,8 @@ from aiogram.types import (
 )
 
 from bot.interfaces.responder import AbstractResponder
+from bot.settings import settings
+from bot.utils.functions import RESOLUTIONS
 
 
 class TelegramResponder(AbstractResponder):
@@ -30,9 +33,22 @@ class TelegramResponder(AbstractResponder):
             disable_notification=True,
         )
 
-    async def send_video(self, file_path: Path, delete_after_send: bool = True) -> None:
+    async def send_video(
+        self,
+        file_path: Path,
+        delete_after_send: bool = True,
+        width: Optional[int] = None,
+        height: Optional[int] = None,
+    ) -> None:
+        if width is None or height is None:
+            resolution = RESOLUTIONS[settings.DEFAULT_RESOLUTION_KEY]
+            width = resolution.width
+            height = resolution.height
+
         await self._message.answer_video(
             video=FSInputFile(file_path),
+            width=width,
+            height=height,
             supports_streaming=True,
             reply_to_message_id=self._message.message_id,
             disable_notification=True,

--- a/bot/interfaces/responder.py
+++ b/bot/interfaces/responder.py
@@ -4,6 +4,7 @@ from abc import (
 )
 import json
 from pathlib import Path
+from typing import Optional
 
 
 class AbstractResponder(ABC):
@@ -14,7 +15,13 @@ class AbstractResponder(ABC):
     @abstractmethod
     async def send_photo(self, image_bytes: bytes, image_path: Path, caption: str) -> None: ...
     @abstractmethod
-    async def send_video(self, file_path: Path, delete_after_send: bool = True) -> None: ...
+    async def send_video(
+        self,
+        file_path: Path,
+        delete_after_send: bool = True,
+        width: Optional[int] = None,
+        height: Optional[int] = None,
+    ) -> None: ...
     @abstractmethod
     async def send_document(self, file_path: Path, caption: str, delete_after_send: bool = True) -> None: ...
     @abstractmethod

--- a/bot/video/clips_compiler.py
+++ b/bot/video/clips_compiler.py
@@ -31,8 +31,7 @@ class ClipsCompiler:
 
             command = [
                 "ffmpeg", "-y", "-f", "concat", "-safe", "0", "-i", str(concat_file_path),
-                "-c", "copy", "-bsf:v", "h264_metadata=sample_aspect_ratio=1/1",
-                "-movflags", "+faststart", "-fflags", "+genpts",
+                "-c", "copy", "-movflags", "+faststart", "-fflags", "+genpts",
                 "-avoid_negative_ts", "1", str(output_file),
             ]
 

--- a/bot/video/clips_extractor.py
+++ b/bot/video/clips_extractor.py
@@ -33,7 +33,6 @@ class ClipsExtractor:
             "-i", str(video_path),
             "-t", str(duration),
             "-c", "copy",
-            "-bsf:v", "h264_metadata=sample_aspect_ratio=1/1",
             "-movflags", "+faststart",
             "-fflags", "+genpts",
             "-avoid_negative_ts", "1",

--- a/preprocessor/video/transcoder.py
+++ b/preprocessor/video/transcoder.py
@@ -76,7 +76,7 @@ class VideoTranscoder(BaseVideoProcessor):
 
         vf_filter = (
             f"scale={self.resolution.width}:{self.resolution.height}:force_original_aspect_ratio=decrease,"
-            f"pad={self.resolution.width}:{self.resolution.height}:(ow-iw)/2:(oh-ih)/2:black"
+            f"pad={self.resolution.width}:{self.resolution.height}:(ow-iw)/2:(oh-ih)/2:black,setsar=1:1"
         )
 
         command = [


### PR DESCRIPTION
Add h264_metadata bitstream filter to force SAR=1:1 in extracted and compiled clips. This fixes squished/incorrect aspect ratio display on Telegram and Signal while maintaining stream copy mode for fast processing without quality loss.