### PR TITLE
Add input to disable E2E tests in workflow

### DIFF
--- a/.github/workflows/build_deploy_test.yml
+++ b/.github/workflows/build_deploy_test.yml
@@ -9,6 +9,12 @@ on:
     types: [submitted]
 
   workflow_dispatch:
+    inputs:
+      disable_tests:
+        description: 'Disable E2E Tests'
+        type: boolean
+        required: false
+        default: false
 
 jobs:
   build_and_test_staging:
@@ -52,6 +58,7 @@ jobs:
           python-version: '3.12'
 
       - name: Run E2E Tests
+        if: ${{ inputs.disable_tests != true }}
         env:
           SECRETS: ${{ secrets.BOT_TEST_ENV }}
           PIP_ROOT_USER_ACTION: ignore


### PR DESCRIPTION
## Description


## Testing

Remember to run the tests when your changes are ready. Workflows can be started from [here](https://github.com/dam2452/RanchBot/actions/workflows/build_deploy_test.yml). Use your branch.

Also, deploy and tests will automatically begin upon PR approval.
